### PR TITLE
Add Revit 2026 support

### DIFF
--- a/AddInManager.sln
+++ b/AddInManager.sln
@@ -27,6 +27,7 @@ Global
 		Debug R23|Any CPU = Debug R23|Any CPU
 		Debug R24|Any CPU = Debug R24|Any CPU
 		Debug R25|Any CPU = Debug R25|Any CPU
+                Debug R26|Any CPU = Debug R26|Any CPU
 		Installer|Any CPU = Installer|Any CPU
 		Release R19|Any CPU = Release R19|Any CPU
 		Release R20|Any CPU = Release R20|Any CPU
@@ -35,6 +36,7 @@ Global
 		Release R23|Any CPU = Release R23|Any CPU
 		Release R24|Any CPU = Release R24|Any CPU
 		Release R25|Any CPU = Release R25|Any CPU
+                Release R26|Any CPU = Release R26|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Debug R22|Any CPU.ActiveCfg = Debug R22|Any CPU
@@ -57,9 +59,13 @@ Global
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R24|Any CPU.ActiveCfg = Release R24|Any CPU
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R24|Any CPU.Build.0 = Release R24|Any CPU
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R25|Any CPU.ActiveCfg = Release R25|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R25|Any CPU.Build.0 = Release R25|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R26|Any CPU.Build.0 = Release R26|Any CPU
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Debug R25|Any CPU.ActiveCfg = Debug R25|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Debug R26|Any CPU.ActiveCfg = Debug R26|Any CPU
 		{C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Debug R25|Any CPU.Build.0 = Debug R25|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Debug R26|Any CPU.Build.0 = Debug R26|Any CPU
 		{E3C87D34-638C-47A0-A73A-D967B119458D}.Debug R22|Any CPU.ActiveCfg = Debug|Any CPU
 		{E3C87D34-638C-47A0-A73A-D967B119458D}.Debug R23|Any CPU.ActiveCfg = Debug|Any CPU
 		{E3C87D34-638C-47A0-A73A-D967B119458D}.Debug R24|Any CPU.ActiveCfg = Debug|Any CPU
@@ -75,6 +81,7 @@ Global
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Debug R22|Any CPU.ActiveCfg = Debug|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Debug R23|Any CPU.ActiveCfg = Debug|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Debug R24|Any CPU.ActiveCfg = Debug|Any CPU
+                {5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Debug R25|Any CPU.ActiveCfg = Debug|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Installer|Any CPU.ActiveCfg = Release|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Release R19|Any CPU.ActiveCfg = Release|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Release R20|Any CPU.ActiveCfg = Release|Any CPU
@@ -83,6 +90,7 @@ Global
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Release R23|Any CPU.ActiveCfg = Release|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Release R24|Any CPU.ActiveCfg = Release|Any CPU
 		{5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Release R25|Any CPU.ActiveCfg = Release|Any CPU
+                {5016ED6D-5A9A-4F59-AE49-CAA9615798F7}.Release R26|Any CPU.ActiveCfg = Release|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R23|Any CPU.ActiveCfg = Debug R23|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R24|Any CPU.ActiveCfg = Debug R24|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Installer|Any CPU.ActiveCfg = Debug R21|Any CPU
@@ -93,8 +101,12 @@ Global
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Release R23|Any CPU.ActiveCfg = Release R23|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Release R24|Any CPU.ActiveCfg = Release R24|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Release R25|Any CPU.ActiveCfg = Release R25|Any CPU
+                {1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R25|Any CPU.ActiveCfg = Release R25|Any CPU
+                {1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R25|Any CPU.Build.0 = Release R25|Any CPU
+                {1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R26|Any CPU.Build.0 = Release R26|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R23|Any CPU.Build.0 = Debug R23|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R22|Any CPU.ActiveCfg = Debug R22|Any CPU
 		{1661572C-EF3A-4DD6-83BD-CB4239CE8CDD}.Debug R22|Any CPU.Build.0 = Debug R22|Any CPU
@@ -118,9 +130,15 @@ Global
 		{21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Release R24|Any CPU.ActiveCfg = Release R24|Any CPU
 		{21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Release R24|Any CPU.Build.0 = Release R24|Any CPU
 		{21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Release R25|Any CPU.ActiveCfg = Release R25|Any CPU
+            {21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Release R25|Any CPU.Build.0 = Release R25|Any CPU
+            {21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Release R26|Any CPU.Build.0 = Release R26|Any CPU
+                {C872CDA2-93F5-4681-BD2F-207EACF83D2E}.Release R26|Any CPU.Build.0 = Release R26|Any CPU
 		{21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Debug R25|Any CPU.ActiveCfg = Release R25|Any CPU
+            {21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Debug R26|Any CPU.ActiveCfg = Release R26|Any CPU
 		{21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Debug R25|Any CPU.Build.0 = Release R25|Any CPU
+            {21460D85-C4AD-49D5-963F-CF13C4AE99EB}.Debug R26|Any CPU.Build.0 = Release R26|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AddInManager/Command/AddinManagerBase.cs
+++ b/AddInManager/Command/AddinManagerBase.cs
@@ -8,7 +8,7 @@ using RevitAddinManager.ViewModel;
 using System.Windows;
 using static RevitAddinManager.App;
 
-#if R25
+#if R25 || R26
 using AssemblyLoadContext = RevitAddinManager.Model.AssemblyLoadContext;
 using System.Runtime.Loader;
 #endif
@@ -87,7 +87,7 @@ public sealed class AddinManagerBase
         return result;
     }
 
-#if R25
+#if R25 || R26
     public Result RunActiveCommand(ExternalCommandData data, ref string message, ElementSet elements)
     {
         var filePath = _activeCmd.FilePath;

--- a/AddInManager/Model/AssemblyLoadContext.cs
+++ b/AddInManager/Model/AssemblyLoadContext.cs
@@ -1,4 +1,4 @@
-﻿#if R25
+﻿#if R25 || R26
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;

--- a/AddInManager/Properties/launchSettings.json
+++ b/AddInManager/Properties/launchSettings.json
@@ -20,6 +20,10 @@
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Autodesk\\Revit 2025\\Revit.exe"
     } ,
+    "Revit2026": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Autodesk\\Revit 2026\\Revit.exe"
+    } ,
     "RevitPreview": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\Autodesk\\Revit Preview Release\\Revit.exe"

--- a/AddInManager/RevitAddinManager.csproj
+++ b/AddInManager/RevitAddinManager.csproj
@@ -5,8 +5,8 @@
     <PlatformTarget>x64</PlatformTarget>
     <ImplicitUsings>true</ImplicitUsings>
     <UseWindowsForms>false</UseWindowsForms>
-    <Configurations>Debug R22;Debug R23;Debug R24;Debug R25</Configurations>
-    <Configurations>$(Configurations);Release R25;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24</Configurations>
+    <Configurations>Debug R22;Debug R23;Debug R24;Debug R25;Debug R26</Configurations>
+    <Configurations>$(Configurations);Release R26;Release R25;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +54,12 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('R26'))">
+    <RevitVersion>2026</RevitVersion>
+    <DefineConstants>$(DefineConstants);R26</DefineConstants>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+  </PropertyGroup>
   <PropertyGroup>
     <Version>$(RevitVersion)</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -78,6 +84,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="$(Configuration.Contains('R25'))">
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(Configuration.Contains('R26'))">
     <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+- 2026-04-10 **1.5.8**
+  - Support Revit 2026 Release
 - 2025-03-23 **1.5.7**
   - Fix click help button in revit 2025
   - Change configuration package to open source maintainer

--- a/Readme.MD
+++ b/Readme.MD
@@ -1,6 +1,6 @@
 
 # Revit Add-in Manager
-![Revit API](https://img.shields.io/badge/Revit%20API%202025-blue.svg) ![Platform](https://img.shields.io/badge/platform-Windows-lightgray.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Revit API](https://img.shields.io/badge/Revit%20API%202026-blue.svg) ![Platform](https://img.shields.io/badge/platform-Windows-lightgray.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ![ReSharper](https://img.shields.io/badge/ReSharper-2023-yellow) ![Rider](https://img.shields.io/badge/Rider-2023-yellow) ![Visual Studio 2022](https://img.shields.io/badge/Visual_Studio_2022-yellow) ![.NET Framework](https://img.shields.io/badge/.NET_8.0-yellow)
 
@@ -110,7 +110,7 @@ The product will be expanded in the future in process to support mutiple platfor
 
 Please follow last release at section [Release](https://github.com/chuongmep/RevitAddInManager/releases/latest)
 
-### Version support : From Revit 2019 to Revit 2025.
+### Version support : From Revit 2019 to Revit 2026.
 
 ---
 

--- a/RevitElementBipChecker/RevitElementBipChecker.csproj
+++ b/RevitElementBipChecker/RevitElementBipChecker.csproj
@@ -8,8 +8,8 @@
 		<Version>1.1.0.0</Version>
 		<AssemblyVersion>1.1.0.*</AssemblyVersion>
 		<Deterministic>false</Deterministic>
-		<Configurations>Debug R22;Debug R23;Debug R24</Configurations>
-		<Configurations>$(Configurations);Release R25;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24</Configurations>
+                <Configurations>Debug R22;Debug R23;Debug R24;Debug R26</Configurations>
+                <Configurations>$(Configurations);Release R26;Release R25;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24</Configurations>
 		<LangVersion>latest</LangVersion>
 		<NoWarn>CS7035</NoWarn>
 	</PropertyGroup>
@@ -53,15 +53,20 @@
 		<TargetFramework>net48</TargetFramework>
 		<DefineConstants>$(DefineConstants);R24</DefineConstants>
 	</PropertyGroup>
-	<PropertyGroup Condition="$(Configuration.Contains('R25'))">
-		<RevitVersion>2025</RevitVersion>
-		<DefineConstants>$(DefineConstants);R25</DefineConstants>
-		<TargetFramework>net8.0-windows</TargetFramework>
-	</PropertyGroup>
-	<PropertyGroup>
-		<Version>$(RevitVersion)</Version>
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<Description>A Project Support Parameter Database for developer in revit</Description>
+        <PropertyGroup Condition="$(Configuration.Contains('R25'))">
+                <RevitVersion>2025</RevitVersion>
+                <DefineConstants>$(DefineConstants);R25</DefineConstants>
+                <TargetFramework>net8.0-windows</TargetFramework>
+        </PropertyGroup>
+        <PropertyGroup Condition="$(Configuration.Contains('R26'))">
+                <RevitVersion>2026</RevitVersion>
+                <DefineConstants>$(DefineConstants);R26</DefineConstants>
+                <TargetFramework>net8.0-windows</TargetFramework>
+        </PropertyGroup>
+        <PropertyGroup>
+                <Version>$(RevitVersion)</Version>
+                <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+                <Description>A Project Support Parameter Database for developer in revit</Description>
 		<AssemblyCopyright>Copyright ©Chuongmep  2023</AssemblyCopyright>
 		<AssemblyTitle>RevitElementBipChecker</AssemblyTitle>
 		<Authors>https://chuongmep.com/</Authors>

--- a/Test/ExecuteDynamicCodeCommand.cs
+++ b/Test/ExecuteDynamicCodeCommand.cs
@@ -62,8 +62,8 @@ public class ExecuteDynamicCodeCommand : IExternalCommand
         
 
         // Add Revit API assemblies explicitly
-        string revitApiPath = @"C:\Program Files\Autodesk\Revit 2025\RevitAPI.dll"; // Modify the path if needed
-        string revitUiPath = @"C:\Program Files\Autodesk\Revit 2025\RevitAPIUI.dll"; // Modify the path if needed
+        string revitApiPath = @"C:\Program Files\Autodesk\Revit 2026\RevitAPI.dll"; // Modify the path if needed
+        string revitUiPath = @"C:\Program Files\Autodesk\Revit 2026\RevitAPIUI.dll"; // Modify the path if needed
 
         references.Add(MetadataReference.CreateFromFile(revitApiPath));
         references.Add(MetadataReference.CreateFromFile(revitUiPath));

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -8,8 +8,8 @@
     <PlatformTarget>x64</PlatformTarget>
     <UseWpf>true</UseWpf>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Configurations>Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;</Configurations>
-    <Configurations>$(Configurations)Release R25;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24</Configurations>
+    <Configurations>Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26;</Configurations>
+    <Configurations>$(Configurations)Release R26;Release R25;Release R19;Release R20;Release R21;Release R22;Release R23;Release R24</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('R19'))">
     <RevitVersion>2019</RevitVersion>
@@ -42,6 +42,14 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <DefineConstants>$(DefineConstants);R25</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(Configuration.Contains('R26'))">
+    <RevitVersion>2026</RevitVersion>
+    <DebugType>Full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <DefineConstants>$(DefineConstants);R26</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <Version>$(RevitVersion)</Version>


### PR DESCRIPTION
## Summary
- add Revit 2026 configuration to projects
- update launch settings for Revit 2026
- document support for Revit 2026
- update dynamic code test paths
- extend solution configurations
- log new version in CHANGELOG
